### PR TITLE
correct regex match in updateKeystore.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,16 +170,19 @@ Deleted: sha256:f8386c6e7763a2ab8917d57912b3df0fc37cb844338900313a7c5eb6164de7ea
 ```
 
 Next, we clean the previous cryptographic certificates on our system is the following command. Note when asked if
-you want to continue, type in `y`: 
-
-```
+you want to continue, type in `y`:
 
 **🚧🚧🚧The command below we clear all docker containers on your system. Only use it
-if you are okay with doing this. I use it everytime to ensure that the containers that 
+if you are okay with doing this. I use it every time to ensure that the containers that 
 are needed for the pattern will work properly, but use at your own discretion.🚧🚧🚧**
-first-network$
-docker stop $(docker ps -a -q)  ; docker rm -f $(docker ps -aq) ; docker system prune -a ; docker volume prune ; docker ps -a ; docker images -a ; docker volume ls
 
+```
+first-network$ docker stop $(docker ps -a -q)  ; docker rm -f $(docker ps -aq) ; docker system prune -a ; docker volume prune ; docker ps -a ; docker images -a ; docker volume ls
+``` 
+
+You will see the following:
+
+```
 WARNING! This will remove all local volumes not used by at least one container.
 Are you sure you want to continue? [y/N] y
 Total reclaimed space: 0B


### PR DESCRIPTION
previous version worked on 1st run but n+1th run would fail due to | not being prefixed with .* any character followed by zero or more of any character(s) 

unwanted append behavior (failure) on n+1th run would reappear in the resulting `connection.yaml` on line 42 and 54 e.g.
```yaml
path: ../../first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/9b39c05b7d2f25164c6a2d567c9b9dbd1dbb58946a896445e0b782620126bbbb_sk9b39c05b7d2f25164c6a2d567c9b9dbd1dbb58946a896445e0b782620126aaaa_sk
```